### PR TITLE
ci: Add concurrency groups to e2e tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -7,6 +7,10 @@ on:
       - ".gitignore"
       - "docs/**"
 
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     runs-on: ai-ubuntu-big-boy-8-core

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   e2e:
-    runs-on: ubuntu-latest 
+    runs-on: ai-ubuntu-big-boy-8-core
 
     steps:
         - name: Checkout Repo

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   e2e:
-    runs-on: ai-ubuntu-big-boy-8-core
+    runs-on: ubuntu-latest 
 
     steps:
         - name: Checkout Repo
@@ -55,4 +55,4 @@ jobs:
 
         - name: Run Tests
           run: |
-            python -m pytest . -v
+            python -m pytest ./tests/e2e -v

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -31,7 +31,7 @@ uds zarf package deploy oci://ghcr.io/defenseunicorns/packages/leapfrogai-api:v0
 # Install the Whisper Backend
 # NOTE: Be sure to use the latest released version at the time you're reading this!
 # NOTE: If you are testing changes you have made locally, you will need to rebuild the Whisper Docker image and Zarf Package.
-uds zarf package deploy oci://ghcr.io/defenseunicorns/packages/whisper:0.5.0 --confirm
+uds zarf package deploy oci://ghcr.io/defenseunicorns/packages/leapfrogai/whisper:0.5.0 --confirm
 
 
 # Install the python dependencies

--- a/tests/e2e/test_main.py
+++ b/tests/e2e/test_main.py
@@ -15,7 +15,6 @@ def test_completions():
             model="whisper",
             prompt="This should result in a failure",
         )
-    print(excinfo.type)
     assert str(excinfo.value) == "Internal Server Error"
 
 


### PR DESCRIPTION
Adding a concurrency group to the e2e tests so that if a new commit is pushed before the previous action run is completed, the workflow will cancel the old run. This saves time and resources.