### PR TITLE
Update setup-zarf version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
       
 
       - name: Install Zarf
-        uses: defenseunicorns/setup-zarf@f95763914e20e493bb5d45d63e30e17138f981d6 # v1.0.0
+        uses: defenseunicorns/setup-zarf@10e539efed02f75ec39eb8823e22a5c795f492ae #v1.0.1
 
       - name: Build Zarf Package
         run: |


### PR DESCRIPTION
This change updates the setup-zarf version to fix issues caused when moving the Zarf repository to a new organization.